### PR TITLE
Install and build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ node_js:
 install:
   - cd project && npm install
 script:
-  - (npm run serve &) ; sleep 10 ; curl -sS -o /dev/null http://localhost:8081
+  - (npm run serve &) ; sleep 10 ; curl -sS -o /dev/null http://localhost:8080

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "node"
+  - "6"
+  - "7"
+install:
+  - cd project && npm install
+script:
+  - (npm run serve &) ; sleep 10 ; curl -sS -o /dev/null http://localhost:8081


### PR DESCRIPTION
- Verify that `npm install` runs successfully on node 6 and node 7.
- Verify that `npm run serve` ends up providing something on http://localhost:8081.

Travis needs to be enabled for the repository for this to work:

https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A

Once this is done, each pull request will generate something like this:

https://travis-ci.org/ithinkihaveacat/pwa-ecommerce-demo/builds/230720374