### PR TITLE
Change the console log clarifying used server port is 8080

### DIFF
--- a/project/server.js
+++ b/project/server.js
@@ -25,4 +25,4 @@ app.all('/checkout/', (req, res) => {
 const PORT = process.env.PORT || 8081;
 app.listen(PORT);
 
-console.log(`Started a local server at http://localhost:${PORT}`);
+console.log(`Started a local server at http://localhost:8080`);

--- a/solution/server.js
+++ b/solution/server.js
@@ -25,4 +25,4 @@ app.all('/checkout/', (req, res) => {
 const PORT = process.env.PORT || 8081;
 app.listen(PORT);
 
-console.log(`Started a local server at http://localhost:${PORT}`);
+console.log(`Started a local server at http://localhost:8080`);


### PR DESCRIPTION
When starting a server, console log indicates the port is 8081 but it's for browser sync and actual server is running on 8080.